### PR TITLE
見た目のアプデ: ヘッダとフッタをちょっとかっこよく

### DIFF
--- a/renderer/components/GeneralSection.tsx
+++ b/renderer/components/GeneralSection.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 import styled from '@emotion/styled'
 
 const MySection = styled.section`
-  margin-left: 8px;
+  text-align: center;
 `
 
 type Props = {

--- a/renderer/components/Layout.tsx
+++ b/renderer/components/Layout.tsx
@@ -6,31 +6,33 @@ import styled from '@emotion/styled'
 const MainBody = styled.div`
   background: #fff;
   margin: 0;
+  a {
+    text-decoration: none;
+    margin-right: 16px;
+    padding-right: 16px;
+    color: #10467c;
+    &:last-child {
+      margin-right: 0;
+      padding-right: 0;
+      border-right: none;
+    }
+    &:hover {
+      opacity: .7;
+      font-style: italic;
+    }
+  }
 `
 
 const MainNav = styled.nav`
   background: #fff;
   text-align: center;
   padding: 4px 0;
-  border-bottom: 1px #c0c0c0 solid;
-  a {
-    text-decoration: none;
-    margin-right: 8px;
-    padding-right: 8px;
-    border-right: 1px #3C3C3C solid;
-    &:last-child {
-      margin-right: 0;
-      padding-right: 0;
-      border-right: none;
-    }
-  }
 `
 
 
 const MainFooter = styled.footer`
   padding: 4px 0 ;
   margin-top: 8px;
-  border-top: 1px #c0c0c0 solid;
   text-align: center;
 `
 
@@ -63,7 +65,7 @@ const Layout = ({ children, title = 'This is the default title' }: Props) => (
       {children}
     </div>
     <MainFooter>
-      <span>© manasas</span>
+      <a href='https://manasas.dev'>© manasas</a>
     </MainFooter>
   </MainBody>
 )

--- a/renderer/components/PathTable.tsx
+++ b/renderer/components/PathTable.tsx
@@ -5,30 +5,51 @@ const PathTable = styled.table`
   border: #4d7eaf 2px solid;
   border-radius: 4px;
 	border-collapse: collapse;
+  margin: 0 auto;
   tr {
     width: 100%;
-    border-top: #4d7eaf 1px solid;
     border-bottom: #4d7eaf 1px solid;
+    &:last-child {
+      border-bottom: none;
+    }
   }
   td {
-    width: 100%;
     padding: 8px 16px;
-    &:hover{
-      opacity: .5;
-      cursor: pointer;
+    border-right: #4d7eaf 1px solid;
+    &:last-child{
+      border-right: none;
     }
   }
 `
+const DownloadTd = styled.td`
+  &:hover{
+  opacity: .5;
+  cursor: pointer;
+  }
+`
+
 
 const onClickGetFile = async (path: string) => {
   global.ipcRenderer.send('download', path)
 }
 
 const htmlPathList = (pathList: string[]) => {
-  return pathList.map((path: string) => {
+  const regexp = new RegExp('[(][0-9]+[)]')
+  const onlynum = new RegExp('[0-9]+')
+  const sortedPathList = pathList.sort((a, b) => {
+    if(a.match(regexp) === null) return -1
+    if(b.match(regexp) === null) return -1
+    const extractA = a.match(regexp)[0]
+    const numA = parseInt(extractA.match(onlynum)[0])
+    const extractB = b.match(regexp)[0]
+    const numB = parseInt(extractB.match(onlynum)[0])
+    return numA - numB
+  })
+  return sortedPathList.map((path: string) => {
     return (
       <tr key={path}>
-        <td onClick={() => onClickGetFile(path)}>{path}</td>
+        <td>{path}</td>
+        <DownloadTd onClick={() => onClickGetFile(path)}>ダウンロード</DownloadTd>
       </tr>
     )
   })

--- a/renderer/components/Title.tsx
+++ b/renderer/components/Title.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled'
 
 const TitleH1 = styled.h1`
   margin-bottom: 4px;
+  text-align: center;
 `
 
 type Props = {

--- a/renderer/pages/index.tsx
+++ b/renderer/pages/index.tsx
@@ -42,7 +42,7 @@ const IndexPage = () => {
       <GeneralSection>
         <SelectedFileArea filePath={filePath} onClickDoImgProcess={ onClickDoImgProcess } />
       </GeneralSection>
-      <Title text="Generated files" />
+      <Title text="生成したファイル" />
       <GeneralSection>
         <PathTable pathList={pathList} />
       </GeneralSection>


### PR DESCRIPTION
# 概要
- #60  
  - ヘッダとフッタをボーダーで区切るのがそこはかとなくダサく感じるのでボーダーを消して、見た目も全体的に中央寄せしました